### PR TITLE
interpret w26 format

### DIFF
--- a/documentation/apidoc.txt
+++ b/documentation/apidoc.txt
@@ -4,106 +4,111 @@ NAME
 CLASSES
         PayloadResponse
         RfidHid
-    
+
     class PayloadResponse(__builtin__.object)
      |  Object representation of the response coming from the device
-     |  
+     |
      |  Methods defined here:
-     |  
+     |
      |  __init__(self, data)
-     |  
+     |
      |  get_crc_sum(self)
      |      Gets the UID+CID CRC Sum check coming from the device
-     |  
+     |
      |  get_raw_data(self)
      |      Gets the response raw data coming from the device
-     |  
+     |
      |  get_tag_cid(self)
      |      Gets the Tag's Customer ID as a 8 bits Integer
-     |  
+     |
      |  get_tag_uid(self)
      |      Gets the Tag's UID as a 32 bits Integer
-     |  
+     |
+     |  get_tag_w26(self)
+     |      Interprets the Tag's UID as W26 (H10301) format.
+     |
+     |      Returns a tuple (facility_code, card_number) or None on format mismatch.
+     |
      |  get_tag_uid_as_byte_sequence(self)
      |      Gets the Tag's UID as a sequence of bytes. E.g. [0x23, 0xa4, 0x23, 0x56]
-     |  
+     |
      |  has_id_data(self)
      |      Check if the response contains the Tag's ID information
-     |  
-     |  
+     |
+     |
      |  ----------------------------------------------------------------------
      |  Data and other attributes defined here:
-     |  
+     |
      |  CID_POS = 12
-     |  
+     |
      |  CRC_READ_POS = 17
-     |  
+     |
      |  RESPONSE_LENGTH_WITH_TAG = 19
-     |  
+     |
      |  UID_LSB_POS = 16
-     |  
+     |
      |  UID_MSB_POS = 13
-     
-    
+
+
     class RfidHid(__builtin__.object)
      |  Main object used to communicate with the device
-     |  
+     |
      |  Methods defined here:
-     |  
+     |
      |  __init__(self, vendor_id=65535, product_id=53)
      |      Open the device using vid and pid
-     |      
+     |
      |      If no arguments are supplied then the default vid and pid will be used.
-     |  
+     |
      |  beep(self, times=1)
      |      Send a command to make the device to emit a "beep"
-     |      
+     |
      |      Arguments:
      |      times -- Number of "beeps" to emit
-     |  
+     |
      |  init(self)
      |      Initialize the device
-     |      
+     |
      |      This method should be use to initialize the device in case the OS does not find it.
      |      Issuing a `sudo lsusb -vd vid:pid` should produce the same result.
-     |  
+     |
      |  read_tag(self)
      |      Send a command to "read a tag" and retrieve the response from the device.
-     |      
+     |
      |      Returns a PayloadResponse object
-     |  
+     |
      |  write_tag(self, ids_bytes)
-     |      Send a command to "write a tag" 
-     |      
+     |      Send a command to "write a tag"
+     |
      |      Arguments:
      |      ids_bytes -- Customer ID + UID to be written in binary byte format.
      |                   Format: [cid, uid_b3, uid_b2, uid_b1, uid_b0]
-     |  
+     |
      |  write_tag_from_cid_and_uid(self, cid, uid)
-     |      Send a command to "write a tag" 
-     |      
+     |      Send a command to "write a tag"
+     |
      |      Arguments:
      |      cid -- (32 bits Integer) Customer ID
      |      uid -- (8 bits Integer)  UID
-     |  
-     |  
+     |
+     |
      |  ----------------------------------------------------------------------
      |  Data and other attributes defined here:
-     |  
+     |
      |  BUFFER_SIZE = 256
-     |  
+     |
      |  CLASS_TYPE_REPORT = 34
-     |  
+     |
      |  CRC_WRITE_INIT_VALUE = 185
-     |  
+     |
      |  DEFAULT_PID = 53
-     |  
+     |
      |  DEFAULT_VID = 65535
-     |  
+     |
      |  GET_REPORT = 1
-     |  
+     |
      |  HID_REPORT_DESCRIPTOR_SIZE = 28
-     |  
+     |
      |  SET_REPORT = 9
 
 

--- a/examples/read.py
+++ b/examples/read.py
@@ -62,6 +62,9 @@ def main():
                 print('uid: %s' % uid)
                 print('customer_id: %s' % payload_response.get_tag_cid())
                 print('CRC Sum: %s' % hex(payload_response.get_crc_sum()))
+                w26 = payload_response.get_tag_w26()
+                if w26:
+                    print('W26: facility code = %d, card number = %d' % w26)
                 print('')
                 rfid.beep()
         else:


### PR DESCRIPTION
Interpret W26 format (facility code + card number), as referenced here: https://www.hidglobal.com/sites/default/files/hid-understanding_card_data_formats-wp-en.pdf

Works for my W26 cards, YMMV.

I also stripped trailing whitespaces. Lmk if you'd like me to separate the actual diff out from whitespace changes.